### PR TITLE
Add Codex Cloud bootstrap script and update environment docs

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,23 +1,19 @@
 # Tools
 
-Brief guide to tooling available to an agent running either in a Codex Cloud environment, a Jules environment, or in this repository's devcontainer.
+Brief guide to tooling available to an agent running in this repository's devcontainer, in Codex Cloud after running `scripts/setup-codex-cloud.sh`, or in Jules after running `scripts/setup-jules.sh`.
 
-See `docs/references/environment-execution-contexts.md` for deeper rationale, source references, and setup-decision process details.
+See `docs/reference/environment-execution-contexts.md` for deeper rationale, source references, and setup-decision process details.
 
 ## Repo-relevant tooling summary
 
-### Available in both environments
+### Installed by `scripts/setup-codex-cloud.sh` and `scripts/setup-jules.sh` when missing
+
+- Core CLI/build tools: `jq`, `ripgrep`, `yq`, `fd` (via `fd-find` + symlink), `eza`
+- Shell tooling: `shellcheck`, `shfmt`
+- Rust workflows: `cargo llvm-cov` (plus `llvm-tools-preview` via `rustup component add` when `rustup` is present)
+
+### Available in devcontainer
 
 - Core CLI/build tools: `git`, `curl`, `jq`, `ripgrep`, `fd`, `zip/unzip`, `build-essential`
 - Rust workflows: `rustup`, `cargo fmt`, `cargo check`, `cargo clippy`, `cargo test`, `cargo llvm-cov`
-
-### Installed in devcontainer and bootstrapped for Codex Cloud/Jules
-
-- `cargo-llvm-cov` for coverage checks
-- `yq` for structured edits/queries in GitHub Actions workflow YAML files and Markdown frontmatter
-- `eza` for filesystem inspection
-- `shellcheck` and `shfmt` for shell script quality and formatting in `scripts/` and related automation
-
-### Devcontainer-only by default
-
-- `gh` (GitHub CLI) is useful in local/devcontainer workflows, but Codex Cloud/Jules agents rely on native GitHub integration and do not require `gh`.
+- Additional quality-of-life tooling: `gh` (GitHub CLI)

--- a/docs/reference/environment-execution-contexts.md
+++ b/docs/reference/environment-execution-contexts.md
@@ -8,7 +8,6 @@ The quick reference lives in `docs/TOOLS.md`.
 
 - Codex Cloud universal image Dockerfile: <https://raw.githubusercontent.com/openai/codex-universal/refs/heads/main/Dockerfile>
 - Codex Cloud default domain allowlist presets: <https://developers.openai.com/codex/cloud/internet-access#preset-domain-lists>
-- Repo-specific domain additions: `` `docs/references/codex-cloud-setup-domain-allowlist.md` ``
 - Jules Environment Setup: <https://jules.google/docs/environment/>
 
 ## Intent
@@ -19,38 +18,34 @@ Environment setup follows the repository knowledge philosophy of progressive dis
 
 1. **Versioned setup over UI-only setup**: setup logic belongs in the repo so it can be branch-tested, code-reviewed, and updated with traceable history.
 2. **Idempotent bootstrap**: setup should be safe to rerun and should only install what is missing.
-3. **Repo-specific parity target**: parity is defined by tools needed for Voicer workflows, not by mirroring every language/runtime in universal images.
+3. **Repo-specific parity target**: parity is defined by tools needed for covgate workflows, not by mirroring every language/runtime in universal images.
 4. **Avoid redundant tooling in cloud**: do not bootstrap tools that duplicate native platform integrations (for example, GitHub CLI in Codex Cloud).
 
+## Decision inputs for `scripts/setup-codex-cloud.sh` and `scripts/setup-jules.sh`
 
-## Decision inputs for `` `scripts/setup-codex-cloud.sh` `` and `scripts/setup-jules.sh`
-
-Tooling included in `` `scripts/setup-codex-cloud.sh` `` and `scripts/setup-jules.sh` is determined by cross-referencing these sources:
+Tooling included in `scripts/setup-codex-cloud.sh` and `scripts/setup-jules.sh` is determined by cross-referencing these sources:
 
 - Devcontainer toolchain baseline: `.devcontainer/Dockerfile`
 - Codex Cloud universal image baseline: <https://raw.githubusercontent.com/openai/codex-universal/refs/heads/main/Dockerfile>
 - Jules VM baseline (Ubuntu Linux preinstalled with Node.js, Python, Go, Java, Rust): <https://jules.google/docs/environment/>
 - Repository workflow requirements and quality gates in code/docs/CI
 
-The setup scripts should only include tools that are needed for Voicer workflows and are not already reliably provided by Codex Cloud or Jules integrations, or their respective base images.
-It should also prefer distribution-derived values (for example, codename detection from `` `/etc/os-release` ``) over hardcoded repository codenames so the bootstrap remains portable as base images evolve.
-This includes deriving OS family and version from `` `/etc/os-release` `` when selecting distribution-specific bootstrap URLs (such as the Microsoft package feed bootstrap `.deb`).
+The setup scripts should only include tools that are needed for covgate workflows and are not already reliably provided by Codex Cloud or Jules integrations, or their respective base images.
+They should also prefer distribution-derived values (for example, codename detection from `/etc/os-release`) over hardcoded repository codenames so the bootstrap remains portable as base images evolve.
 
 ## Tool-selection rationale by environment
 
 The devcontainer Dockerfile is intended to support both human developers and CLI/VS Code extension agents running inside the container. That dual audience guides a broader tool selection there.
 
-Codex Cloud and Jules setup is narrower and should include only tooling required for repository workflows that is not already provided by the respective cloud platform or base image.
-
-For some tools (for example Task and TFLint), the bootstrap may prefer GitHub release binaries over third-party apt feeds to reduce external repository dependencies and avoid extra allowlist requirements.
+Codex Cloud and Jules setup is narrower and should include only tooling required for repository workflows that is not already provided by the platform or base image.
 
 ## Operational workflow
 
 1. Update setup script and docs in a branch.
-2. Configure Codex Cloud setup command to call `` `scripts/setup-codex-cloud.sh` `` or Jules to call `scripts/setup-jules.sh`.
+2. Configure Codex Cloud setup command to call `scripts/setup-codex-cloud.sh` and Jules setup command to call `scripts/setup-jules.sh`.
 3. Validate required tool availability and task execution from that branch.
 4. Merge after validation.
 
 ## Network allowlist considerations
 
-When setup scripts add external package sources, record required additional domains in `` `docs/references/codex-cloud-setup-domain-allowlist.md` `` so administrators can update Codex Cloud network policies intentionally.
+Current setup scripts do not require additional repository-specific allowlist entries beyond Codex Cloud defaults. If that changes in the future, document the required domains in this file.

--- a/scripts/setup-codex-cloud.sh
+++ b/scripts/setup-codex-cloud.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${CODEX_DEBUG:-}" == "1" || "${CODEX_SETUP_DEBUG:-}" == "1" ]]; then
+	set -x
+fi
+
+if [[ "$(id -u)" -eq 0 ]]; then
+	SUDO=""
+else
+	SUDO="sudo"
+fi
+
+if ! command -v apt-get >/dev/null 2>&1; then
+	echo "This setup script currently supports Debian/Ubuntu environments with apt-get." >&2
+	exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+need_cmd() {
+	local cmd="$1"
+	! command -v "$cmd" >/dev/null 2>&1
+}
+
+ensure_fd_command() {
+	if need_cmd fd && ! need_cmd fdfind; then
+		local fdfind_path
+		fdfind_path="$(command -v fdfind)"
+		$SUDO ln -sf "$fdfind_path" /usr/local/bin/fd
+		echo "setup-codex-cloud: linked fd -> ${fdfind_path}"
+	fi
+}
+
+APT_PACKAGES=()
+
+# Useful agentic tooling
+need_cmd jq && APT_PACKAGES+=(jq)
+need_cmd rg && APT_PACKAGES+=(ripgrep)
+need_cmd yq && APT_PACKAGES+=(yq)
+need_cmd fdfind && APT_PACKAGES+=(fd-find)
+need_cmd eza && APT_PACKAGES+=(eza)
+need_cmd shellcheck && APT_PACKAGES+=(shellcheck)
+need_cmd shfmt && APT_PACKAGES+=(shfmt)
+
+if ((${#APT_PACKAGES[@]} > 0)); then
+	$SUDO apt-get update
+	$SUDO apt-get install -y --no-install-recommends "${APT_PACKAGES[@]}"
+	echo "setup-codex-cloud: installed apt packages: ${APT_PACKAGES[*]}"
+else
+	echo "setup-codex-cloud: required apt-managed tools already present; nothing to install."
+fi
+
+ensure_fd_command
+
+# Rust workflow tools
+if need_cmd rustup; then
+	echo "setup-codex-cloud: rustup not found, skipping rust toolchain setup"
+else
+	rustup component add llvm-tools-preview || true
+fi
+
+if ! cargo llvm-cov --version >/dev/null 2>&1; then
+	echo "setup-codex-cloud: installing cargo-llvm-cov"
+	cargo install cargo-llvm-cov --locked
+else
+	echo "setup-codex-cloud: cargo-llvm-cov already installed"
+fi
+
+echo "setup-codex-cloud: Complete!"


### PR DESCRIPTION
### Motivation

- Provide an idempotent bootstrap mechanism to install repository-required CLI tooling in Codex Cloud/Jules environments when missing. 
- Make devcontainer vs cloud/Jules tool differences explicit in the top-level tooling guide and tie them to repository setup scripts. 
- Align documentation to the repository's operational target (covgate workflows) and centralize rationale in the reference doc.

### Description

- Add `scripts/setup-codex-cloud.sh`, a Debian/Ubuntu `apt`-based bootstrap that installs missing tools (`jq`, `ripgrep`, `yq`, `fd-find`, `eza`, `shellcheck`, `shfmt`), links `fdfind` to `fd`, adds the `llvm-tools-preview` component via `rustup` when available, and installs `cargo-llvm-cov` with `cargo` if missing. 
- Update `docs/TOOLS.md` to clarify where tools are installed (devcontainer vs bootstrap scripts), adjust the tool lists ordered by installation source, and fix the reference path to `docs/reference/environment-execution-contexts.md`. 
- Update `docs/reference/environment-execution-contexts.md` to rename the intent to target `covgate` workflows, add a Decision inputs section for `scripts/setup-codex-cloud.sh` and `scripts/setup-jules.sh`, simplify several operational sentences, and note current allowlist behavior.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b37a5bed3c8326a258d9f29677f12b)