### PR TITLE
Add `xtask` validate command and wire into local hooks/workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Format
         run: cargo fmt --check
-      - name: Check
-        run: cargo check
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,5 @@
 - `src/` – Rust code for the `covgate` linter.
 
 ## Rust Workflow
-- Format Rust code with `cargo fmt`.
-- Run `cargo check` as the fast baseline compiler verification step.
-- Run `cargo deny check` for dependency and advisory policy validation.
-- Lint Rust code with `cargo clippy --all-targets --all-features -- -D warnings`.
-- Run `cargo test` for the automated test suite.
-- Run `cargo llvm-cov --summary-only` and keep coverage at or above 80% across the codebase before considering work complete.
+- Run `cargo xtask validate` before considering work complete.
 - Address bug reports and review findings with TDD: first reproduce the issue in a failing test, then fix the issue and rerun the relevant tests until they pass.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3.15"
+
+[workspace]
+members = [".", "xtask"]

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -13,7 +13,7 @@ is_zero_sha() {
 
 is_relevant_path() {
     case "$1" in
-        src/*|tests/*|benches/*|examples/*|.cargo/*|Cargo.toml|Cargo.lock|build.rs|rust-toolchain|rust-toolchain.toml|covgate.toml|deny.toml)
+        src/*|tests/*|benches/*|examples/*|.cargo/*|Cargo.toml|Cargo.lock|build.rs|rust-toolchain|rust-toolchain.toml|covgate.toml|deny.toml|xtask/*)
             return 0
             ;;
         *)
@@ -58,17 +58,5 @@ if [ "$should_run" -eq 0 ]; then
     exit 0
 fi
 
-coverage_json=$(mktemp "${TMPDIR:-/tmp}/covgate-pre-push-XXXXXX.json")
-trap 'rm -f "$coverage_json"' EXIT INT TERM HUP
-
-echo "Running cargo clippy --all-targets --all-features -- -D warnings"
-cargo clippy --all-targets --all-features -- -D warnings
-
-echo "Running cargo llvm-cov --json --output-path $coverage_json"
-cargo llvm-cov --json --output-path "$coverage_json"
-
-echo "Running cargo deny check advisories licenses sources bans"
-cargo deny check advisories licenses sources bans
-
-echo "Running covgate dogfood check via cargo run --bin covgate -- --coverage-json $coverage_json"
-cargo run --bin covgate -- --coverage-json "$coverage_json"
+echo "Running cargo xtask validate"
+cargo xtask validate

--- a/scripts/setup-codex-cloud.sh
+++ b/scripts/setup-codex-cloud.sh
@@ -67,6 +67,13 @@ else
 	echo "setup-codex-cloud: cargo-llvm-cov already installed"
 fi
 
+if ! cargo machete --version >/dev/null 2>&1; then
+	echo "setup-codex-cloud: installing cargo-machete"
+	cargo install cargo-machete --locked
+else
+	echo "setup-codex-cloud: cargo-machete already installed"
+fi
+
 if ! cargo deny --version >/dev/null 2>&1; then
 	echo "setup-codex-cloud: installing cargo-deny"
 	cargo install cargo-deny --locked

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+anyhow = "1.0"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,120 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    let Some(task) = args.next() else {
+        bail!("usage: cargo xtask <task>");
+    };
+
+    match task.as_str() {
+        "validate" => validate(),
+        _ => bail!("unknown xtask `{task}`"),
+    }
+}
+
+fn validate() -> Result<()> {
+    run("cargo", &["fmt", "--check"])?;
+    run(
+        "cargo",
+        &[
+            "clippy",
+            "--all-targets",
+            "--all-features",
+            "--",
+            "-D",
+            "warnings",
+        ],
+    )?;
+
+    let coverage_json = coverage_path();
+    let coverage_json_str = coverage_json
+        .to_str()
+        .context("coverage output path contained non-utf8 characters")?;
+
+    run(
+        "cargo",
+        &[
+            "llvm-cov",
+            "--json",
+            "--output-path",
+            coverage_json_str,
+            "--fail-under-regions=88",
+        ],
+    )?;
+
+    let base_ref = resolve_base_ref()?;
+    run(
+        "cargo",
+        &[
+            "run",
+            "--bin",
+            "covgate",
+            "--",
+            "--coverage-json",
+            coverage_json_str,
+            "--base",
+            &base_ref,
+        ],
+    )?;
+
+    run("cargo-machete", &["."])?;
+    run("cargo-deny", &["check"])?;
+
+    std::fs::remove_file(&coverage_json).ok();
+    Ok(())
+}
+
+fn resolve_base_ref() -> Result<String> {
+    for candidate in ["origin/main", "origin/master", "main", "master", "HEAD~1"] {
+        if git_ref_exists(candidate) {
+            return Ok(candidate.to_owned());
+        }
+    }
+
+    bail!("unable to resolve a usable git base reference for covgate dogfooding")
+}
+
+fn git_ref_exists(reference: &str) -> bool {
+    Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", reference])
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn coverage_path() -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "covgate-xtask-validate-{}-{}.json",
+        std::process::id(),
+        chrono_like_timestamp()
+    ));
+    path
+}
+
+fn chrono_like_timestamp() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
+}
+
+fn run(program: &str, args: &[&str]) -> Result<()> {
+    eprintln!("> {} {}", program, args.join(" "));
+    let status = Command::new(program)
+        .args(args)
+        .status()
+        .with_context(|| format!("failed to execute `{program}`"))?;
+
+    if !status.success() {
+        bail!(
+            "command `{program} {}` failed with status {status}",
+            args.join(" ")
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Consolidate local quality checks into a single developer-facing entrypoint to reduce duplication and make pre-push checks easier to run and maintain.
- Dogfood the tool by running `covgate` against a real git base ref as part of local validation.
- Remove a redundant `cargo check` step from CI while keeping CI checks separate and explicit.
- Ensure the developer setup script installs `cargo-machete` (in addition to `cargo-deny`) so the new validation pipeline can run out-of-the-box.

### Description
- Add a new `xtask` crate with `cargo xtask validate` that runs `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo llvm-cov --json --output-path <tmp> --fail-under-regions=88`, runs `covgate` dogfooding against a resolved git base ref, then `cargo-machete` and `cargo-deny` (files: `xtask/Cargo.toml`, `xtask/src/main.rs`).
- Wire a Cargo alias so `cargo xtask ...` works via `.cargo/config.toml` and add the new crate to the workspace in `Cargo.toml`.
- Replace the per-command invocations in `scripts/pre-push` with a single `cargo xtask validate` call and extend the hook to treat `xtask/*` as a relevant path.
- Simplify the Rust workflow guidance in `AGENTS.md` to advise running `cargo xtask validate`, remove `cargo check` from `.github/workflows/ci.yml`, and update `scripts/setup-codex-cloud.sh` to install `cargo-machete` if missing (retaining `cargo-deny` install logic).

### Testing
- Ran `cargo fmt` successfully to ensure formatting changes are clean and `xtask` code is formatted.
- Executed `cargo xtask validate`, which performed the full pipeline (format check, clippy, `cargo llvm-cov` with coverage gate, `covgate` dogfooding, `cargo-machete`, and `cargo-deny`) and completed successfully after installing missing tools.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48ff746d48326aaa8036194abcd78)