### PR TITLE
Fallback to `cargo run` for agent maintenance `record-base`

### DIFF
--- a/scripts/agent-env-maintenance.sh
+++ b/scripts/agent-env-maintenance.sh
@@ -14,7 +14,16 @@ record_base_ref() {
 	fi
 
 	if ! command -v covgate >/dev/null 2>&1; then
-		echo "${SETUP_LABEL}: covgate not found; skipping covgate record-base" >&2
+		if ! command -v cargo >/dev/null 2>&1; then
+			echo "${SETUP_LABEL}: covgate and cargo not found; skipping covgate record-base" >&2
+			return 0
+		fi
+
+		if cargo run --quiet -- record-base; then
+			echo "${SETUP_LABEL}: recorded stable base ref via cargo run"
+		else
+			echo "${SETUP_LABEL}: cargo run -- record-base failed; continuing" >&2
+		fi
 		return 0
 	fi
 


### PR DESCRIPTION
### Motivation
- The maintenance script may run before a built `covgate` binary is available in `PATH`, causing `record-base` to be skipped and leaving agent worktrees without a recorded base.
- Provide a local build-time fallback so `record-base` can run in developer or CI environments by invoking the crate via `cargo` when the binary is absent.

### Description
- Updated `scripts/agent-env-maintenance.sh` in the `record_base_ref` function to detect when `covgate` is not on `PATH` and instead check for `cargo`.
- If `cargo` is available the script runs `cargo run --quiet -- record-base` and logs success or non-fatal failure messages, then returns early; the original `covgate record-base` path remains unchanged when the binary is present.
- Error and status messages were preserved and clarified so the script continues safely on failure without aborting the maintenance flow.

### Testing
- Ran a shell syntax check with `bash -n scripts/agent-env-maintenance.sh` which succeeded.
- Executed `bash scripts/agent-env-maintenance.sh test-maintenance` which recorded the worktree base via the `cargo run` fallback and printed a recorded base message.
- Ran the full repository validation with `cargo xtask validate`, which completed successfully (unit and integration tests passed and the `covgate` CLI invocation in the validation run produced a successful coverage report).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b78c1762dc832685ebb8ad0ad7426f)