### PR TITLE
Show all available nonzero metrics in markdown summary and add Missed column

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,16 @@ pub fn run(config: Config) -> Result<i32> {
     requested_metrics.sort();
     requested_metrics.dedup();
 
+    let available_metrics = report
+        .totals_by_file
+        .iter()
+        .filter(|(_, totals)| totals.values().any(|file_totals| file_totals.total > 0))
+        .map(|(metric, _)| *metric)
+        .filter(|metric| !requested_metrics.contains(metric))
+        .collect::<Vec<_>>();
+
+    requested_metrics.extend(available_metrics);
+
     for metric_kind in requested_metrics {
         let metric = metrics::compute_changed_metric(&report, &diff, metric_kind)?;
         metrics.push(metric);

--- a/src/render/markdown.rs
+++ b/src/render/markdown.rs
@@ -103,20 +103,22 @@ pub fn render(result: &GateResult, _diff_description: &str) -> String {
         let metric_label = title_case(metric.metric.label());
         out.push_str(&format!("#### {}\n\n", title_case(metric.metric.as_str())));
         out.push_str(&format!(
-            "| File | Covered {metric_label} | {metric_label} | Coverage |\n"
+            "| File | Covered {metric_label} | {metric_label} | Missed {metric_label} | Coverage |\n"
         ));
-        out.push_str("| --- | ---: | ---: | ---: |\n");
+        out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
         for (path, totals) in &metric.totals_by_file {
             let percent = if totals.total == 0 {
                 100.0
             } else {
                 (totals.covered as f64 / totals.total as f64) * 100.0
             };
+            let missed = totals.total.saturating_sub(totals.covered);
             out.push_str(&format!(
-                "| `{}` | {} | {} | {:.2}% |\n",
+                "| `{}` | {} | {} | {} | {:.2}% |\n",
                 path.display(),
                 totals.covered,
                 totals.total,
+                missed,
                 percent
             ));
         }
@@ -135,9 +137,10 @@ pub fn render(result: &GateResult, _diff_description: &str) -> String {
         } else {
             (overall_covered as f64 / overall_total as f64) * 100.0
         };
+        let overall_missed = overall_total.saturating_sub(overall_covered);
         out.push_str(&format!(
-            "| **Total** | **{}** | **{}** | **{:.2}%** |\n",
-            overall_covered, overall_total, overall_percent
+            "| **Total** | **{}** | **{}** | **{}** | **{:.2}%** |\n",
+            overall_covered, overall_total, overall_missed, overall_percent
         ));
         out.push('\n');
     }
@@ -213,10 +216,81 @@ mod tests {
         ));
         assert!(rendered.contains("| `src/lib.rs` | 1 | 2 | 50.00% |"));
         assert!(rendered.contains("| **Total** | **1** | **2** | **50.00%** |  |"));
-        assert!(rendered.contains("| File | Covered Regions | Regions | Coverage |"));
-        assert!(rendered.contains("| **Total** | **3** | **4** | **75.00%** |"));
+        assert!(
+            rendered.contains("| File | Covered Regions | Regions | Missed Regions | Coverage |")
+        );
+        assert!(rendered.contains("| `src/lib.rs` | 3 | 4 | 1 | 75.00% |"));
+        assert!(rendered.contains("| **Total** | **3** | **4** | **1** | **75.00%** |"));
         assert!(rendered.contains("### Overall Coverage"));
         assert!(!rendered.contains("Informational only. Does not affect the gate result in v1."));
+    }
+
+    #[test]
+    fn renders_all_nonzero_metrics_in_markdown_summary() {
+        let result = GateResult {
+            metrics: vec![
+                crate::model::ComputedMetric {
+                    metric: MetricKind::Region,
+                    covered: 1,
+                    total: 2,
+                    percent: 50.0,
+                    uncovered_changed_opportunities: Vec::new(),
+                    changed_totals_by_file: BTreeMap::from([(
+                        PathBuf::from("src/lib.rs"),
+                        FileTotals {
+                            covered: 1,
+                            total: 2,
+                        },
+                    )]),
+                    totals_by_file: BTreeMap::from([(
+                        PathBuf::from("src/lib.rs"),
+                        FileTotals {
+                            covered: 3,
+                            total: 4,
+                        },
+                    )]),
+                },
+                crate::model::ComputedMetric {
+                    metric: MetricKind::Line,
+                    covered: 2,
+                    total: 2,
+                    percent: 100.0,
+                    uncovered_changed_opportunities: Vec::new(),
+                    changed_totals_by_file: BTreeMap::from([(
+                        PathBuf::from("src/lib.rs"),
+                        FileTotals {
+                            covered: 2,
+                            total: 2,
+                        },
+                    )]),
+                    totals_by_file: BTreeMap::from([(
+                        PathBuf::from("src/lib.rs"),
+                        FileTotals {
+                            covered: 5,
+                            total: 5,
+                        },
+                    )]),
+                },
+            ],
+            rules: vec![RuleOutcome {
+                rule: GateRule::Percent {
+                    metric: MetricKind::Region,
+                    minimum_percent: 90.0,
+                },
+                passed: false,
+                observed_percent: 50.0,
+                observed_uncovered_count: 0,
+            }],
+            passed: false,
+        };
+
+        let rendered = render(&result, "origin/main...HEAD");
+        assert!(rendered.contains("#### Region"));
+        assert!(rendered.contains("#### Line"));
+        assert!(rendered.contains(
+            "| File | Covered Changed Lines | Changed Lines | Coverage | Missed Changed Spans |"
+        ));
+        assert!(rendered.contains("| File | Covered Lines | Lines | Missed Lines | Coverage |"));
     }
 
     #[test]

--- a/tests/cli_interface.rs
+++ b/tests/cli_interface.rs
@@ -332,6 +332,11 @@ fn markdown_summary_rust_fixture() {
         "| File | Covered Changed Regions | Changed Regions | Coverage | Missed Changed Spans |"
     ));
     assert!(markdown.contains("### Overall Coverage"));
+    assert!(markdown.contains("#### Region"));
+    assert!(markdown.contains("#### Line"));
+    assert!(markdown.contains("#### Function"));
+    assert!(markdown.contains("| File | Covered Regions | Regions | Missed Regions | Coverage |"));
+    assert!(markdown.contains("| **Total** | **"));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Improve the Markdown summary UX by rendering every available metric with nonzero totals, not only metrics that are actively gated. 
- Make overall coverage tables more informative by adding a per-file and overall `Missed <Metric>` column so readers can see uncovered counts alongside percentages.

### Description
- Change metric selection in `run` to compute requested gated metrics first and then append any other available metrics that have nonzero totals so they appear in summaries (`src/lib.rs`).
- Update the markdown renderer to include a `Missed {metric}` column in the `### Overall Coverage` tables and compute per-file and overall missed counts (`src/render/markdown.rs`).
- Adjust the per-metric table header/formatting in markdown to include the missed counts and ensure numeric columns align as before (`src/render/markdown.rs`).
- Add and update unit and integration tests to cover the new summary layout and behavior, including rendering multiple nonzero metrics and asserting the new missed column is present (`src/render/markdown.rs` tests and `tests/cli_interface.rs`).

### Testing
- Ran focused unit tests `cargo test markdown_summary_rust_fixture -- --nocapture` and `cargo test renders_markdown_tables -- --nocapture`, both passed. 
- Ran the new renderer unit test `cargo test renders_all_nonzero_metrics_in_markdown_summary -- --nocapture`, which passed. 
- Verified CLI integration and metric behavior with `cargo test branch_metric_unavailable_for_rust_fixture -- --nocapture`, which passed. 
- Ran the repository validation flow `cargo xtask quick` and `cargo xtask validate`, and all checks and test suites completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb1d22b8748326b44055d8ad425eb7)