### PR TITLE
ci: upgrade actions/upload-artifact to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
             "${{ matrix.archive_format }}"
 
       - name: Upload release archive artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-${{ matrix.target }}
           path: dist/*


### PR DESCRIPTION
### Motivation
- Move off the Node.js 20-backed `actions/upload-artifact@v4` to a v6 release that supports Node.js 24 and avoids the upcoming deprecation risk.

### Description
- Replace `actions/upload-artifact@v4` with `actions/upload-artifact@v6` in `.github/workflows/release.yml` while keeping the existing artifact name, path, and `if-no-files-found` behavior intact and commit the change.

### Testing
- Ran `cargo xtask quick` which completed successfully, and ran `cargo xtask validate` which failed during the `covgate-check` step because the local checkout lacks an auto-discoverable Git base ref (the failure is unrelated to the workflow version change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd8acec8d0832680f068ae849b6fcf)