### PR TITLE
ignore taiki-e/install-action in dependabot and simplify cargo groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     labels:
       - ci
       - dependencies
+    ignore:
+      - dependency-name: "taiki-e/install-action"
     groups:
       ci-minor-patch:
         patterns:
@@ -22,25 +24,6 @@ updates:
     labels:
       - dependencies
     groups:
-      rust-development-tools:
-        patterns:
-          - "assert_cmd"
-          - "criterion"
-          - "insta"
-          - "mockall"
-          - "predicates"
-          - "pretty_assertions"
-          - "proptest"
-          - "rstest"
-          - "serial_test"
-          - "snapbox"
-          - "tempfile"
-          - "tokio-test"
-          - "trycmd"
-          - "wiremock"
-        update-types:
-          - minor
-          - patch
       rust-minor-patch:
         patterns:
           - "*"


### PR DESCRIPTION
### Motivation
- Prevent Dependabot from opening updates for `taiki-e/install-action` in the `github-actions` ecosystem to reduce noise and avoid unwanted automation changes. 
- Simplify the cargo update configuration by removing a specialized `rust-development-tools` group and relying on a single catch-all `rust-minor-patch` grouping.

### Description
- Added an `ignore` entry for `taiki-e/install-action` under the `github-actions` update entry in `.github/dependabot.yml`.
- Removed the `rust-development-tools` cargo group and left the existing `rust-minor-patch` group that matches all cargo dependencies.
- Change is limited to `.github/dependabot.yml` and does not modify runtime code.

### Testing
- Ran `cargo xtask validate` as required by repository policy and all linting and coverage steps completed successfully except one environment-specific check. 
- The `covgate-check` step (invoking `cargo run --bin covgate -- check ...`) failed because the base ref could not be auto-detected in this environment, which is an expected validation failure in this CI-less run. 
- All unit and integration test suites executed by `cargo xtask validate` passed during the run (other validation steps such as `fmt`, `clippy`, `llvm-cov`, and `cargo-deny` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eccb8234408326b948b698cd3514ef)