### PR TITLE
add devcontainer config and pin rust version with rust-toolchain.toml

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+	"name": "covgate",
+	"image": "mcr.microsoft.com/devcontainers/base:trixie",
+	"features": {
+		"ghcr.io/devcontainers/features/nix:1": {
+			"multiUser": false,
+			"extraNixConfig": "experimental-features = nix-command flakes"
+		}
+	},
+	"runArgs": [
+		"--name=covgate"
+	],
+	"containerEnv": {
+		"HOME_LOCAL_NIX": "${containerWorkspaceFolder}/.devcontainer/local.nix",
+		"WORKSPACE_FOLDER": "${containerWorkspaceFolder}"
+	},
+	"remoteEnv": {
+		"PATH": "/home/vscode/.nix-profile/bin:/home/vscode/.cargo/bin:${containerEnv:PATH}"
+	},
+	"postCreateCommand": "bash .devcontainer/post-create-command.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"openai.chatgpt",
+				"redhat.vscode-yaml",
+				"ms-azuretools.vscode-containers",
+				"anthropic.claude-code",
+				"jnoortheen.nix-ide",
+				"codesmith.markdown-inline-editor-vscode",
+				"yzhang.markdown-all-in-one",
+				"rust-lang.rust-analyzer",
+				"tamasfe.even-better-toml"
+			]
+		}
+	}
+}

--- a/.devcontainer/flake.lock
+++ b/.devcontainer/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777308348,
+        "narHash": "sha256-DJx9wnerjsOqKOo8I7/u5ENRhRWFF2mbYcACF+mn5LU=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "a28e848a01044f47679453aae75f6253bef7903e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/.devcontainer/flake.nix
+++ b/.devcontainer/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "Devcontainer Home Manager configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, home-manager, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+      localModule = ./. + "/local.nix";
+      localModules =
+        if builtins.pathExists localModule
+        then [ localModule ]
+        else [ ];
+    in {
+      homeConfigurations.vscode = home-manager.lib.homeManagerConfiguration {
+        inherit pkgs;
+        modules = [
+          ./home.nix
+          ({ pkgs, ... }: {
+            home.packages = with pkgs; [
+              # Core CLI tools
+              curl
+              git
+              jq
+              yq-go
+              ripgrep
+              fd
+              eza
+              gh
+              zip
+              unzip
+              file
+              which
+              less
+              tree
+              python3
+
+              # Shell/script tooling
+              shellcheck
+              shfmt
+
+              # Native fixture/build support
+              gnumake
+              pkg-config
+              cmake
+              ninja
+              clang
+              llvmPackages.llvm
+
+              # Rust tooling
+              rustup
+              cargo-llvm-cov
+              cargo-deny
+              cargo-machete
+              cargo-binstall
+            ];
+          })
+        ] ++ localModules;
+      };
+    };
+}

--- a/.devcontainer/home.nix
+++ b/.devcontainer/home.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  home.username = "vscode";
+  home.homeDirectory = "/home/vscode";
+  home.stateVersion = "23.11";
+
+  programs.home-manager.enable = true;
+}

--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+nix run "path:${SCRIPT_DIR}#homeConfigurations.vscode.activationPackage"
+
+export PATH="${HOME}/.nix-profile/bin:${HOME}/.cargo/bin:${PATH}"
+
+cd "${WORKSPACE_FOLDER:-${SCRIPT_DIR}/..}"
+
+if ! rustup show active-toolchain >/dev/null 2>&1; then
+  rustup toolchain install
+fi
+
+if ! command -v covgate >/dev/null 2>&1; then
+  cargo install covgate --locked
+fi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,10 @@ updates:
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: rust-toolchain
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -10,10 +10,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: stable
-          components: clippy, rustfmt
+      - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
       - uses: taiki-e/install-action@4eac87a84609e7a285bcfd82df34e948017a9fcb # main
         with:
           tool: cargo-llvm-cov@0.8.5
@@ -32,9 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: stable
+      - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
       - uses: taiki-e/install-action@4eac87a84609e7a285bcfd82df34e948017a9fcb # main
         with:
           tool: cargo-machete@0.9.1
@@ -45,9 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        with:
-          toolchain: stable
+      - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
       - uses: taiki-e/install-action@4eac87a84609e7a285bcfd82df34e948017a9fcb # main
         with:
           tool: cargo-deny@0.19.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .codex
+local.nix

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI](https://github.com/jesse-black/covgate/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jesse-black/covgate/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/covgate.svg)](https://crates.io/crates/covgate)
-[![docs.rs](https://img.shields.io/docsrs/covgate)](https://docs.rs/covgate)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 
 Teams don’t merge a repository; they merge a diff.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+[toolchain]
+channel = "1.95.0"
+components = [
+  "clippy",
+  "llvm-tools-preview",
+  "rust-src",
+  "rustfmt",
+]

--- a/src/git.rs
+++ b/src/git.rs
@@ -228,7 +228,7 @@ pub fn discover_base_ref() -> Result<Option<String>> {
     for candidate in STANDARD_BASE_REFS
         .iter()
         .copied()
-        .chain([RECORDED_BASE_REF].into_iter())
+        .chain([RECORDED_BASE_REF])
     {
         if resolve_ref_sha(candidate)?.is_some() {
             return Ok(Some(candidate.to_string()));


### PR DESCRIPTION
- add devcontainer config
- pin rust version with rust-toolchain.toml
- fix clippy warning appearing after upgrading to rust 1.95.0