### PR TITLE
Simplify clap CLI metadata to use default version and about

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,17 +1,9 @@
-use clap::{ArgAction, Args as ClapArgs, Parser, Subcommand};
+use clap::{Args as ClapArgs, Parser, Subcommand};
 use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
-#[command(
-    name = "covgate",
-    about = "Diff-focused coverage gate",
-    version,
-    disable_version_flag = true
-)]
+#[command(version, about)]
 pub struct Cli {
-    #[arg(short = 'v', short_alias = 'V', long = "version", action = ArgAction::Version)]
-    _version: Option<bool>,
-
     #[command(subcommand)]
     pub command: Command,
 }

--- a/tests/cli_interface.rs
+++ b/tests/cli_interface.rs
@@ -187,11 +187,7 @@ fn help_lists_record_base_as_subcommand() {
 fn version_switches_report_current_binary_version() {
     let temp = tempdir().expect("tempdir should exist");
 
-    for args in [
-        vec!["--version".to_string()],
-        vec!["-V".to_string()],
-        vec!["-v".to_string()],
-    ] {
+    for args in [vec!["--version".to_string()], vec!["-V".to_string()]] {
         let output = run_covgate_raw(temp.path(), &args);
         assert_eq!(output.status.code(), Some(0), "args={args:?}");
         let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");


### PR DESCRIPTION
The `clap` CLI metadata parsing structure has been simplified. Instead of explicitly capturing `-v`, `-V`, and `--version` manually using an `Option<bool>` mapped to `ArgAction::Version`, the standard macro attributes `#[command(version, about)]` are utilized to let `clap` fetch `version` and `about` implicitly from the `Cargo.toml`. Since standard behavior uses only `-V` and `--version` without custom override mappings, `-v` flag support has been removed and the integration tests updated to match.

---
*PR created automatically by Jules for task [16480980632599959890](https://jules.google.com/task/16480980632599959890) started by @jesse-black*