### PR TITLE
smart untracked files error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # AGENTS
 
+## Step 0 (required before keyword-searching for documentation)
+Run `docgarden match <query>` before using `rg`, `grep`, `find`, or agents to locate Markdown documentation, plans, repository guidance, or repository-local skills.
+Use this when your first instinct is to search docs or guidance by keyword.
+Run `docgarden ls --active-plans` to list active ExecPlans when continuing or checking current plan-driven work.
+Do not repeat this step when the relevant file is already named by the user, listed in this file, or still in active context.
+Do not use this step for code-first work, code symbol searches, test names, compiler errors, or known file paths; inspect and search code directly.
+
 ## Development Process
 ### Must Follow
 - Run `cargo xtask validate` before declaring Rust behavior changes complete, including parser, metric, gate, CLI behavior, fixture, or validation-policy changes. For documentation-only, CI-only, metadata-only, or lint/config-only changes, run the focused checks that exercise the touched surface instead.

--- a/docs/exec-plans/active/0026-smart-untracked-warning.md
+++ b/docs/exec-plans/active/0026-smart-untracked-warning.md
@@ -1,0 +1,86 @@
+---
+description: "ExecPlan for filtering the untracked-files check to only coverage-relevant files and promoting it to a fail-fast error; read when implementing or reviewing this change."
+---
+
+# Smart Untracked-Files Check: Intersect with Coverage Files and Fail Fast
+
+## Goal
+`emit_untracked_files_warning` is replaced by a fail-fast error that only triggers when at least one untracked file is also present in the coverage report. Untracked files with no coverage entry are silently ignored. When coverage-relevant untracked files are found, covgate exits non-zero with a clear error message and the exact `git add -N` command to fix it.
+
+## Scope
+- In: `src/lib.rs` — `run`, `load_changed_lines_with_warnings`, `emit_untracked_files_warning` (renamed), and their private helpers.
+- In: `tests/cli_interface.rs` — existing untracked-warning tests updated to assert error exit; new intersection tests added.
+- In: `tests/lib_run.rs` — existing untracked-warning tests updated to assert `Err`; new intersection tests added.
+- Out: `src/git.rs` — `list_untracked_files` is unchanged.
+- Out: `src/diff.rs`, `src/config.rs`, `src/model.rs`, renderers, parsers.
+
+## Decisions
+
+### Warning vs. error promotion: promote to fail-fast error
+Once intersection filtering eliminates false positives, every remaining hit is a genuine problem: an untracked file that covgate tracks but cannot see in the diff, which produces a silent false pass. The fix is always the same trivially-copy-paste command (`git add -N <path>`) that the error message provides. Keeping it as a warning leaves users unknowingly running on bad data after an expensive coverage run; erroring stops them immediately. Truly new files that will never be tracked are rare, so the blast radius of a hard error is low. No suppression flag is needed because the intersection filter already acts as the suppression mechanism for irrelevant files.
+
+## Relevant Areas
+- `src/lib.rs:20-34` — `run` loads `report` before calling `load_changed_lines_with_warnings`; the report is already available to thread through.
+- `src/lib.rs:236-246` — `supported_files(report)` already computes the `BTreeSet<PathBuf>` of repo-relative covered file paths.
+- `src/lib.rs:248-268` — `load_changed_lines_with_warnings` and `emit_untracked_files_warning` — the two functions to change.
+- `src/git.rs:129-142` — `list_untracked_files()` returns repo-relative `Vec<String>`; unchanged.
+- `tests/cli_interface.rs:397-466` — existing untracked-warning CLI tests; `git_base_mode_warns_about_untracked_files` and `diff_file_mode_skips_untracked_files_warning`.
+- `tests/lib_run.rs:58-125` — existing lib-level untracked-warning tests; `run_with_git_base_checks_untracked_files_before_loading_diff`, `run_with_git_base_quotes_paths_in_add_command_when_needed`, `run_with_git_base_skips_warning_when_no_untracked_files_exist`.
+
+## Open Questions
+None.
+
+## Steps
+
+### src/lib.rs — production changes
+- [ ] In `run`: call `supported_files(&report)` before `load_changed_lines_with_warnings` and bind to `coverage_files`; pass `&coverage_files` as a second argument to `load_changed_lines_with_warnings`.
+- [ ] Change `load_changed_lines_with_warnings` signature to accept `coverage_files: &BTreeSet<std::path::PathBuf>`; pass `coverage_files` through to the check function.
+- [ ] Rename `emit_untracked_files_warning` to `check_untracked_coverage_files`; update its signature to accept `coverage_files: &BTreeSet<std::path::PathBuf>`.
+- [ ] Inside `check_untracked_coverage_files`: after obtaining `untracked_files`, filter to only those whose `PathBuf` appears in `coverage_files`; bind the filtered list as `relevant`; if `relevant.is_empty()` return `Ok(())`.
+- [ ] When `relevant` is non-empty, return `Err(...)` (using the existing error type) with a message that names the coverage-relevance criterion and includes the exact fix command, e.g.: `"untracked files appear in the coverage report and are excluded from diff gating, which produces a false pass — add them with: \`{add_command}\`"`. Do not print to stderr and continue; the error propagates and causes a non-zero exit.
+
+### tests/cli_interface.rs — test updates
+- [ ] Rename and update `git_base_mode_warns_about_untracked_files` → `git_base_mode_errors_on_coverage_untracked_files`: replace the `new_untracked.rs` untracked file with a file at a path present in the fixture's coverage report (e.g., `src/lib.rs` removed from index). Assert the command exits non-zero and stderr contains the fix command naming that path.
+- [ ] Add new test `git_base_mode_passes_for_uncovered_untracked_file`: create an untracked file at a path not in coverage (e.g., `new_untracked.rs`). Assert the command exits zero and stderr does not contain the error text.
+- [ ] Rename `diff_file_mode_skips_untracked_files_warning` → `diff_file_mode_skips_untracked_files_check` (diff-file mode never errors regardless of coverage membership); update assertions to match error-vs-warning framing if needed.
+
+### tests/lib_run.rs — test updates
+- [ ] Rename and update `run_with_git_base_checks_untracked_files_before_loading_diff`: replace `new_untracked.rs` with a coverage-present file removed from index. Assert the result is `Err` and the error message contains the fix command.
+- [ ] Update `run_with_git_base_quotes_paths_in_add_command_when_needed`: this test uses `"space name.rs"` which is not in coverage — it will no longer trigger an error. Replace with a coverage-present file whose path contains a space, or if that is impractical in the harness, add a separate test for quoting using a coverage-present path with a space and convert the original to assert `Ok` behavior for an irrelevant untracked file. The generator should choose the simplest option that preserves quoting coverage.
+- [ ] Update `run_with_git_base_skips_warning_when_no_untracked_files_exist`: rename to `run_with_git_base_passes_when_no_untracked_files_exist`; intent unchanged (no untracked files → `Ok`).
+
+## Validation
+- `cargo test git_base_mode_errors_on_coverage_untracked_files`
+- `cargo test git_base_mode_passes_for_uncovered_untracked_file`
+- `cargo test diff_file_mode_skips_untracked_files_check`
+- `cargo test run_with_git_base_checks_untracked_files_before_loading_diff`
+- `cargo test run_with_git_base_quotes_paths_in_add_command_when_needed`
+- `cargo test run_with_git_base_passes_when_no_untracked_files_exist`
+- `cargo test --workspace`
+- `cargo xtask validate`
+
+## Discoveries
+- `run` in `src/lib.rs` already loads `report` (line 32) before the warning is emitted (line 33 via `load_changed_lines_with_warnings`), so threading `supported_files(&report)` through requires no reordering of pipeline steps.
+- `supported_files` returns `BTreeSet<PathBuf>` with repo-relative paths. `list_untracked_files` returns `Vec<String>` of repo-relative paths. Converting each untracked string to `PathBuf` and checking set membership is a one-liner per path.
+- The rust basic-pass fixture's coverage JSON references exactly one file: `src/lib.rs`. Tests that need a "coverage-present" untracked file should use this path.
+- `run_with_git_base_quotes_paths_in_add_command_when_needed` currently relies on a non-coverage file to trigger the warning path; it will silently pass after this change. The generator must resolve this per the guidance in Steps.
+
+## Review
+None yet.
+
+## Definition of Done
+
+### Planner
+- [x] Plan is consistent, up to date, decision-complete, and ready to hand off.
+
+### Generator
+- [ ] Goal achieved: check errors (not warns) when untracked files intersect with coverage-tracked files; passes silently otherwise.
+- [ ] All planned steps are complete.
+- [ ] All validation commands pass.
+- [ ] Handed off to an independent reviewer (MUST use the `evaluator-execplan` skill via a subagent or separate agent, not the generator agent).
+
+### Evaluator
+- [ ] Standard review posture applied.
+- [ ] Adheres to the principles of `docs/CODESTYLE.md`.
+- [ ] Adheres to the principles of `docs/TESTING.md`.
+- [ ] All review findings have been addressed.

--- a/docs/exec-plans/active/0026-smart-untracked-warning.md
+++ b/docs/exec-plans/active/0026-smart-untracked-warning.md
@@ -33,29 +33,30 @@ None.
 ## Steps
 
 ### src/lib.rs — production changes
-- [ ] In `run`: call `supported_files(&report)` before `load_changed_lines_with_warnings` and bind to `coverage_files`; pass `&coverage_files` as a second argument to `load_changed_lines_with_warnings`.
-- [ ] Change `load_changed_lines_with_warnings` signature to accept `coverage_files: &BTreeSet<std::path::PathBuf>`; pass `coverage_files` through to the check function.
-- [ ] Rename `emit_untracked_files_warning` to `check_untracked_coverage_files`; update its signature to accept `coverage_files: &BTreeSet<std::path::PathBuf>`.
-- [ ] Inside `check_untracked_coverage_files`: after obtaining `untracked_files`, filter to only those whose `PathBuf` appears in `coverage_files`; bind the filtered list as `relevant`; if `relevant.is_empty()` return `Ok(())`.
-- [ ] When `relevant` is non-empty, return `Err(...)` (using the existing error type) with a message that names the coverage-relevance criterion and includes the exact fix command, e.g.: `"untracked files appear in the coverage report and are excluded from diff gating, which produces a false pass — add them with: \`{add_command}\`"`. Do not print to stderr and continue; the error propagates and causes a non-zero exit.
+- [x] In `run`: call `supported_files(&report)` before `load_changed_lines_with_warnings` and bind to `coverage_files`; pass `&coverage_files` as a second argument to `load_changed_lines_with_warnings`.
+- [x] Change `load_changed_lines_with_warnings` signature to accept `coverage_files: &BTreeSet<std::path::PathBuf>`; pass `coverage_files` through to the check function.
+- [x] Rename `emit_untracked_files_warning` to `check_untracked_coverage_files`; update its signature to accept `coverage_files: &BTreeSet<std::path::PathBuf>`.
+- [x] Inside `check_untracked_coverage_files`: after obtaining `untracked_files`, filter to only those whose `PathBuf` appears in `coverage_files`; bind the filtered list as `relevant`; if `relevant.is_empty()` return `Ok(())`.
+- [x] When `relevant` is non-empty, return `Err(...)` (using the existing error type) with a message that names the coverage-relevance criterion and includes the exact fix command, e.g.: `"untracked files appear in the coverage report and are excluded from diff gating, which produces a false pass — add them with: \`{add_command}\`"`. Do not print to stderr and continue; the error propagates and causes a non-zero exit.
 
 ### tests/cli_interface.rs — test updates
-- [ ] Rename and update `git_base_mode_warns_about_untracked_files` → `git_base_mode_errors_on_coverage_untracked_files`: replace the `new_untracked.rs` untracked file with a file at a path present in the fixture's coverage report (e.g., `src/lib.rs` removed from index). Assert the command exits non-zero and stderr contains the fix command naming that path.
-- [ ] Add new test `git_base_mode_passes_for_uncovered_untracked_file`: create an untracked file at a path not in coverage (e.g., `new_untracked.rs`). Assert the command exits zero and stderr does not contain the error text.
-- [ ] Rename `diff_file_mode_skips_untracked_files_warning` → `diff_file_mode_skips_untracked_files_check` (diff-file mode never errors regardless of coverage membership); update assertions to match error-vs-warning framing if needed.
+- [x] Rename and update `git_base_mode_warns_about_untracked_files` → `git_base_mode_errors_on_coverage_untracked_files`: uses `git rm --cached src/lib.rs` to make the coverage-present file untracked. Asserts non-zero exit and stderr contains fix command.
+- [x] Add new test `git_base_mode_passes_for_uncovered_untracked_file`: create an untracked file at a path not in coverage (e.g., `new_untracked.rs`). Assert the command exits zero and stderr does not contain the error text.
+- [x] Rename `diff_file_mode_skips_untracked_files_warning` → `diff_file_mode_skips_untracked_files_check`; assertion updated from "Untracked-files warning" to "false pass".
 
 ### tests/lib_run.rs — test updates
-- [ ] Rename and update `run_with_git_base_checks_untracked_files_before_loading_diff`: replace `new_untracked.rs` with a coverage-present file removed from index. Assert the result is `Err` and the error message contains the fix command.
-- [ ] Update `run_with_git_base_quotes_paths_in_add_command_when_needed`: this test uses `"space name.rs"` which is not in coverage — it will no longer trigger an error. Replace with a coverage-present file whose path contains a space, or if that is impractical in the harness, add a separate test for quoting using a coverage-present path with a space and convert the original to assert `Ok` behavior for an irrelevant untracked file. The generator should choose the simplest option that preserves quoting coverage.
-- [ ] Update `run_with_git_base_skips_warning_when_no_untracked_files_exist`: rename to `run_with_git_base_passes_when_no_untracked_files_exist`; intent unchanged (no untracked files → `Ok`).
+- [x] Rename `run_with_git_base_checks_untracked_files_before_loading_diff` → `run_with_git_base_errors_on_coverage_untracked_files`: uses `git rm --cached src/lib.rs`. Asserts `Err` with fix command.
+- [x] Rename `run_with_git_base_quotes_paths_in_add_command_when_needed` → `run_with_git_base_passes_for_uncovered_untracked_file_with_spaces`: now asserts `Ok` (non-coverage untracked file). Added new test `run_with_git_base_quotes_coverage_paths_with_spaces_in_error_command` using a custom coverage JSON with `src/my lib.rs`; asserts error message contains properly shell-quoted path.
+- [x] Rename `run_with_git_base_skips_warning_when_no_untracked_files_exist` → `run_with_git_base_passes_when_no_untracked_files_exist`; intent unchanged.
 
 ## Validation
 - `cargo test git_base_mode_errors_on_coverage_untracked_files`
 - `cargo test git_base_mode_passes_for_uncovered_untracked_file`
 - `cargo test diff_file_mode_skips_untracked_files_check`
-- `cargo test run_with_git_base_checks_untracked_files_before_loading_diff`
-- `cargo test run_with_git_base_quotes_paths_in_add_command_when_needed`
-- `cargo test run_with_git_base_passes_when_no_untracked_files_exist`
+- `cargo test --test lib_run run_with_git_base_errors_on_coverage_untracked_files`
+- `cargo test --test lib_run run_with_git_base_passes_for_uncovered_untracked_file_with_spaces`
+- `cargo test --test lib_run run_with_git_base_quotes_coverage_paths_with_spaces_in_error_command`
+- `cargo test --test lib_run run_with_git_base_passes_when_no_untracked_files_exist`
 - `cargo test --workspace`
 - `cargo xtask validate`
 
@@ -66,7 +67,61 @@ None.
 - `run_with_git_base_quotes_paths_in_add_command_when_needed` currently relies on a non-coverage file to trigger the warning path; it will silently pass after this change. The generator must resolve this per the guidance in Steps.
 
 ## Review
-None yet.
+
+### Finding 1 — CODESTYLE: `list_untracked_files` private wrapper does not earn its layer
+
+**File:** `src/lib.rs:281-283`
+
+```rust
+fn list_untracked_files() -> Result<Vec<String>> {
+    crate::git::list_untracked_files()
+}
+```
+
+This is a pure single-line alias. It adds no logic, no error transformation, no testability seam. `check_untracked_coverage_files` should call `crate::git::list_untracked_files()` directly. CODESTYLE Principle 4: "Earn every layer."
+
+---
+
+### Finding 2 — PLAN: Validation section lists two stale test names
+
+**File:** `docs/exec-plans/active/0026-smart-untracked-warning.md`, Validation section
+
+The Validation section still lists the old pre-rename test names that no longer exist in the codebase:
+
+- `cargo test run_with_git_base_checks_untracked_files_before_loading_diff` — renamed to `run_with_git_base_errors_on_coverage_untracked_files`
+- `cargo test run_with_git_base_quotes_paths_in_add_command_when_needed` — renamed to `run_with_git_base_passes_for_uncovered_untracked_file_with_spaces`
+
+Running these commands produces 0 tests filtered in (they silently pass without exercising anything). The three new test names introduced by the generator are also absent from the Validation list:
+
+- `run_with_git_base_errors_on_coverage_untracked_files`
+- `run_with_git_base_passes_for_uncovered_untracked_file_with_spaces`
+- `run_with_git_base_quotes_coverage_paths_with_spaces_in_error_command`
+
+The Validation section must be updated to reflect the actual test names.
+
+---
+
+### Finding 3 — TESTING: `diff_file_mode_skips_untracked_files_check` does not assert the intended behavior
+
+**File:** `tests/cli_interface.rs:443-473`
+
+The test creates `new_untracked.rs`, a file that is not present in the coverage report. Using a non-coverage untracked file means the test cannot distinguish the "diff mode skips the check entirely" behavior from the "git-base mode silently ignores non-coverage untracked files" behavior — both exit zero and emit no error text for a non-coverage file.
+
+To assert that diff mode actually bypasses the check, the untracked file must be one that is present in the coverage report (e.g., `src/lib.rs` via `git rm --cached`). With a coverage-tracked untracked file: git-base mode errors, diff-file mode passes. The current test cannot falsify a broken implementation that skips diff-mode suppression but still passes because the file has no coverage entry.
+
+TESTING.md Principle 5: "A test's value is what it can falsify."
+
+---
+
+### Finding 4 — TESTING: `git_base_mode_errors_on_coverage_untracked_files` uses `assert_ne` where `assert_eq!(Some(1))` is the codebase norm
+
+**File:** `tests/cli_interface.rs:413`
+
+```rust
+assert_ne!(output.status.code(), Some(0));
+```
+
+Every other error-exit assertion in `cli_interface.rs` uses `assert_eq!(output.status.code(), Some(1))`. The `assert_ne` form passes for any non-zero exit code including 2 (clap usage error) and `None` (killed process). `run()` errors propagate through `main` via `anyhow::Result<()>` and exit with code 1; the assertion should be `assert_eq!(output.status.code(), Some(1))` to match that contract and the surrounding test file convention.
 
 ## Definition of Done
 
@@ -74,13 +129,13 @@ None yet.
 - [x] Plan is consistent, up to date, decision-complete, and ready to hand off.
 
 ### Generator
-- [ ] Goal achieved: check errors (not warns) when untracked files intersect with coverage-tracked files; passes silently otherwise.
-- [ ] All planned steps are complete.
-- [ ] All validation commands pass.
-- [ ] Handed off to an independent reviewer (MUST use the `evaluator-execplan` skill via a subagent or separate agent, not the generator agent).
+- [x] Goal achieved: check errors (not warns) when untracked files intersect with coverage-tracked files; passes silently otherwise.
+- [x] All planned steps are complete.
+- [x] All validation commands pass.
+- [x] Handed off to an independent reviewer (MUST use the `evaluator-execplan` skill via a subagent or separate agent, not the generator agent).
 
 ### Evaluator
-- [ ] Standard review posture applied.
-- [ ] Adheres to the principles of `docs/CODESTYLE.md`.
-- [ ] Adheres to the principles of `docs/TESTING.md`.
-- [ ] All review findings have been addressed.
+- [x] Standard review posture applied.
+- [x] Adheres to the principles of `docs/CODESTYLE.md`.
+- [x] Adheres to the principles of `docs/TESTING.md`.
+- [x] All review findings have been addressed.

--- a/docs/exec-plans/completed/0026-smart-untracked-warning.md
+++ b/docs/exec-plans/completed/0026-smart-untracked-warning.md
@@ -123,6 +123,17 @@ assert_ne!(output.status.code(), Some(0));
 
 Every other error-exit assertion in `cli_interface.rs` uses `assert_eq!(output.status.code(), Some(1))`. The `assert_ne` form passes for any non-zero exit code including 2 (clap usage error) and `None` (killed process). `run()` errors propagate through `main` via `anyhow::Result<()>` and exit with code 1; the assertion should be `assert_eq!(output.status.code(), Some(1))` to match that contract and the surrounding test file convention.
 
+### Re-review — 2026-05-11
+
+No open findings. The current branch addresses the prior review notes:
+
+- `src/lib.rs` now calls `crate::git::list_untracked_files()` directly rather than using an unearned private wrapper.
+- `docs/exec-plans/active/0026-smart-untracked-warning.md` lists the current validation commands.
+- `tests/cli_interface.rs::diff_file_mode_skips_untracked_files_check` now uses `git rm --cached src/lib.rs`, so diff-file mode is tested with a coverage-present untracked file.
+- `tests/cli_interface.rs::git_base_mode_errors_on_coverage_untracked_files` now asserts `Some(1)`.
+
+Validation evidence: `cargo xtask validate` passed on 2026-05-11.
+
 ## Definition of Done
 
 ### Planner

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@ pub fn run(config: Config) -> Result<i32> {
     let markdown_output = &markdown_output;
 
     let report = coverage::load_from_path(coverage_report)?;
-    let diff = load_changed_lines_with_warnings(diff_source)?;
+    let coverage_files = supported_files(&report);
+    let diff = load_changed_lines_with_warnings(diff_source, &coverage_files)?;
 
     let mut overall_metrics = Vec::new();
     for kind in [
@@ -245,30 +246,36 @@ fn supported_files(report: &crate::model::CoverageReport) -> BTreeSet<std::path:
         .collect()
 }
 
-fn load_changed_lines_with_warnings(source: &DiffSource) -> Result<Vec<ChangedFile>> {
-    emit_untracked_files_warning(source)?;
+fn load_changed_lines_with_warnings(
+    source: &DiffSource,
+    coverage_files: &BTreeSet<std::path::PathBuf>,
+) -> Result<Vec<ChangedFile>> {
+    check_untracked_coverage_files(source, coverage_files)?;
     diff::load_changed_lines(source)
 }
 
-fn emit_untracked_files_warning(source: &DiffSource) -> Result<()> {
+fn check_untracked_coverage_files(
+    source: &DiffSource,
+    coverage_files: &BTreeSet<std::path::PathBuf>,
+) -> Result<()> {
     if !matches!(source, DiffSource::GitBase(_)) {
         return Ok(());
     }
 
-    let untracked_files = list_untracked_files()?;
-    if untracked_files.is_empty() {
+    let untracked_files = crate::git::list_untracked_files()?;
+    let relevant: Vec<String> = untracked_files
+        .into_iter()
+        .filter(|path| coverage_files.contains(std::path::Path::new(path)))
+        .collect();
+
+    if relevant.is_empty() {
         return Ok(());
     }
 
-    let add_command = format_git_add_command(&untracked_files);
-    eprintln!(
-        "⚠️ Untracked-files warning: untracked files are not included in diff gating and can produce a false pass. Add them with: `{add_command}`."
-    );
-    Ok(())
-}
-
-fn list_untracked_files() -> Result<Vec<String>> {
-    crate::git::list_untracked_files()
+    let add_command = format_git_add_command(&relevant);
+    Err(anyhow::anyhow!(
+        "untracked files appear in the coverage report and are excluded from diff gating, which produces a false pass — add them with: `{add_command}`"
+    ))
 }
 
 fn format_git_add_command(paths: &[String]) -> String {

--- a/tests/cli_interface.rs
+++ b/tests/cli_interface.rs
@@ -394,7 +394,7 @@ fn diff_file_mode_skips_dirty_worktree_guard() {
 }
 
 #[test]
-fn git_base_mode_warns_about_untracked_files() {
+fn git_base_mode_errors_on_coverage_untracked_files() {
     let fixture = rust_basic_pass_fixture();
     let temp = tempdir().expect("tempdir should exist");
     let worktree = setup_fixture_worktree(temp.path(), fixture);
@@ -406,42 +406,47 @@ fn git_base_mode_warns_about_untracked_files() {
     run_git(&worktree, &["add", "covgate.toml"]);
     run_git(&worktree, &["commit", "-m", "add covgate config"]);
 
+    run_git(&worktree, &["rm", "--cached", "src/lib.rs"]);
+
+    let output = run_covgate(&worktree, fixture, &[]);
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(stderr.contains("false pass"), "stderr={stderr}");
+    assert!(stderr.contains("git add -N src/lib.rs"), "stderr={stderr}");
+}
+
+#[test]
+fn git_base_mode_passes_for_uncovered_untracked_file() {
+    let fixture = rust_basic_pass_fixture();
+    let temp = tempdir().expect("tempdir should exist");
+    let worktree = setup_fixture_worktree(temp.path(), fixture);
     fs::write(
-        worktree.join("new_untracked.rs"),
-        "pub fn pending() {}
-",
+        worktree.join("covgate.toml"),
+        "[[gates]]\nfail-under-regions = 90\n",
     )
-    .expect("untracked file should write");
+    .expect("config should be written");
+    run_git(&worktree, &["add", "covgate.toml"]);
+    run_git(&worktree, &["commit", "-m", "add covgate config"]);
+
+    fs::write(worktree.join("new_untracked.rs"), "pub fn pending() {}\n")
+        .expect("untracked file should write");
 
     let output = run_covgate(&worktree, fixture, &[]);
 
     assert_eq!(output.status.code(), Some(0));
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(
-        stderr.contains("Untracked-files warning"),
-        "stderr={stderr}"
-    );
-    assert!(stderr.contains("false pass"), "stderr={stderr}");
-    assert!(stderr.contains("Add them with:"), "stderr={stderr}");
-    assert!(
-        stderr.contains("git add -N new_untracked.rs"),
-        "stderr={stderr}"
-    );
+    assert!(!stderr.contains("false pass"), "stderr={stderr}");
 }
 
 #[test]
-fn diff_file_mode_skips_untracked_files_warning() {
+fn diff_file_mode_skips_untracked_files_check() {
     let fixture = rust_basic_pass_fixture();
     let temp = tempdir().expect("tempdir should exist");
     let worktree = setup_fixture_worktree(temp.path(), fixture);
     let diff_file = write_worktree_diff(temp.path(), &worktree);
 
-    fs::write(
-        worktree.join("new_untracked.rs"),
-        "pub fn pending() {}
-",
-    )
-    .expect("untracked file should write");
+    run_git(&worktree, &["rm", "--cached", "src/lib.rs"]);
     fs::write(
         worktree.join("covgate.toml"),
         "[[gates]]\nfail-under-regions = 90\n",
@@ -459,10 +464,7 @@ fn diff_file_mode_skips_untracked_files_warning() {
 
     assert_eq!(output.status.code(), Some(0));
     let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
-    assert!(
-        !stderr.contains("Untracked-files warning"),
-        "stderr={stderr}"
-    );
+    assert!(!stderr.contains("false pass"), "stderr={stderr}");
 }
 
 #[test]

--- a/tests/lib_run.rs
+++ b/tests/lib_run.rs
@@ -55,13 +55,12 @@ fn run_with_diff_file_executes_without_untracked_warning_lookup() {
 }
 
 #[test]
-fn run_with_git_base_checks_untracked_files_before_loading_diff() {
+fn run_with_git_base_errors_on_coverage_untracked_files() {
     let _lock = CWD_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
     let fixture = support::rust_basic_pass_fixture();
     let temp = tempdir().expect("tempdir should exist");
     let worktree = support::setup_fixture_worktree(temp.path(), fixture);
-    fs::write(worktree.join("new_untracked.rs"), "pub fn pending() {}\n")
-        .expect("untracked file should write");
+    support::run_git(&worktree, &["rm", "--cached", "src/lib.rs"]);
     let previous = env::current_dir().expect("cwd should resolve");
     let _guard = CwdGuard(previous);
     env::set_current_dir(&worktree).expect("should chdir into worktree");
@@ -73,13 +72,16 @@ fn run_with_git_base_checks_untracked_files_before_loading_diff() {
 
     let config =
         Config::try_from(git_base_args(fixture.coverage_json())).expect("config should resolve");
-    let code = run(config).expect("run should succeed");
+    let err = run(config).expect_err("run should fail when coverage-present file is untracked");
 
-    assert_eq!(code, 0);
+    assert!(
+        err.to_string().contains("git add -N src/lib.rs"),
+        "error={err}"
+    );
 }
 
 #[test]
-fn run_with_git_base_quotes_paths_in_add_command_when_needed() {
+fn run_with_git_base_passes_for_uncovered_untracked_file_with_spaces() {
     let _lock = CWD_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
     let fixture = support::rust_basic_pass_fixture();
     let temp = tempdir().expect("tempdir should exist");
@@ -103,7 +105,45 @@ fn run_with_git_base_quotes_paths_in_add_command_when_needed() {
 }
 
 #[test]
-fn run_with_git_base_skips_warning_when_no_untracked_files_exist() {
+fn run_with_git_base_quotes_coverage_paths_with_spaces_in_error_command() {
+    let _lock = CWD_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
+    let fixture = support::rust_basic_pass_fixture();
+    let temp = tempdir().expect("tempdir should exist");
+    let worktree = support::setup_fixture_worktree(temp.path(), fixture);
+    let coverage_path = temp.path().join("coverage-with-space.json");
+    let original =
+        fs::read_to_string(fixture.coverage_json()).expect("fixture coverage should be readable");
+    fs::write(
+        &coverage_path,
+        original.replace("\"src/lib.rs\"", "\"src/my lib.rs\""),
+    )
+    .expect("modified coverage should be written");
+    fs::write(
+        worktree.join("src").join("my lib.rs"),
+        "pub fn pending() {}\n",
+    )
+    .expect("untracked file with space should write");
+    let previous = env::current_dir().expect("cwd should resolve");
+    let _guard = CwdGuard(previous);
+    env::set_current_dir(&worktree).expect("should chdir into worktree");
+    fs::write(
+        worktree.join("covgate.toml"),
+        "[[gates]]\nfail-under-regions = 90\n",
+    )
+    .expect("config should write");
+
+    let config = Config::try_from(git_base_args(coverage_path)).expect("config should resolve");
+    let err = run(config)
+        .expect_err("run should fail when coverage-present untracked file has spaces in path");
+
+    assert!(
+        err.to_string().contains("git add -N 'src/my lib.rs'"),
+        "error={err}"
+    );
+}
+
+#[test]
+fn run_with_git_base_passes_when_no_untracked_files_exist() {
     let _lock = CWD_LOCK.lock().unwrap_or_else(|poison| poison.into_inner());
     let fixture = support::rust_basic_pass_fixture();
     let temp = tempdir().expect("tempdir should exist");


### PR DESCRIPTION
- untracked files now errors instead of warning
- only untracked files that are also in coverage triggers an error